### PR TITLE
Update tonic to satisfy cargo audit 

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -6,8 +6,8 @@ edition = "2021"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-prost = "0.11"
-tonic = "0.8"
+prost = "0.12"
+tonic = "0.10"
 
 [build-dependencies]
-tonic-build = "0.8"
+tonic-build = "0.10"

--- a/README.md
+++ b/README.md
@@ -10,6 +10,7 @@ This package translates protobuf definitions for SpiceDB hosted on
 
 ### Prequisites
 
+0. Make sure protoc is installed - https://grpc.io/docs/protoc-installation
 1. Install `buf` CLI - https://docs.buf.build/installation
 2. Install `cargo-make` - `cargo install cargo-make`
 


### PR DESCRIPTION
https://github.com/StructionSite/smart-track/pull/1598 is blocked by cargo audit, this is one of the places that needs updating 